### PR TITLE
Use Jenkins app service plugin to deploy webapp

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,9 @@ node {
     azureUtil.deployDataApp(targetEnv, azureUtil.config.WEST_EUROPE_GROUP)
 
     // Deploy web app
-    azureUtil.deployWebApp(azureUtil.config.EAST_US_GROUP)
-    azureUtil.deployWebApp(azureUtil.config.WEST_EUROPE_GROUP)
+    dir('web-app/target') {
+        azureUtil.deployWebApp(azureUtil.config.EAST_US_GROUP, "docker/Dockerfile")
+        azureUtil.deployWebApp(azureUtil.config.WEST_EUROPE_GROUP, "docker/Dockerfile")
+    }
   }
 }

--- a/deployment/jenkins/docker-master/Dockerfile
+++ b/deployment/jenkins/docker-master/Dockerfile
@@ -18,8 +18,8 @@ RUN /usr/local/bin/install-plugins.sh \
     ws-cleanup \
     ant \
     gradle \
-    workflow-job:2.10 \
-    workflow-multibranch:2.10 \
+    workflow-job \
+    workflow-multibranch \
     workflow-aggregator \
     github-organization-folder \
     pipeline-stage-view \
@@ -33,4 +33,5 @@ RUN /usr/local/bin/install-plugins.sh \
     mailer \
     kubernetes \
     job-dsl \
-    groovy
+    groovy \
+    azure-app-service

--- a/deployment/jenkins/docker-master/init.groovy
+++ b/deployment/jenkins/docker-master/init.groovy
@@ -4,6 +4,7 @@
  * license information.
  */
 
+import groovy.json.JsonSlurper
 import hudson.model.*
 import jenkins.model.*
 import hudson.security.FullControlOnceLoggedInAuthorizationStrategy
@@ -18,6 +19,7 @@ import com.cloudbees.plugins.credentials.*
 import com.cloudbees.plugins.credentials.common.*
 import com.cloudbees.plugins.credentials.domains.*
 import com.cloudbees.plugins.credentials.impl.*
+import com.microsoft.azure.util.AzureCredentials
 
 /**
  * Set up security for the Jenkins instance with below configuration.
@@ -95,6 +97,42 @@ void addKubeCredential(String credentialId) {
     SystemCredentialsProvider.getInstance().getStore().addCredentials(Domain.global(), kubeCredential)
 }
 
+void addACRCredential(String credentialId, String configFile) {
+    String content = new File(configFile).text
+    def jsonSlurper = new JsonSlurper()
+    def config = jsonSlurper.parseText(content)
+
+    def acrCredential = new UsernamePasswordCredentialsImpl(
+        CredentialsScope.GLOBAL,
+        credentialId,
+        'Azure Container Registry',
+        config.aadClientId,
+        config.aadClientSecret
+    )
+    SystemCredentialsProvider.getInstance().getStore().addCredentials(Domain.global(), acrCredential)
+}
+
+void addAzureCredential(String credentialId, String configFile) {
+    String content = new File(configFile).text
+    def jsonSlurper = new JsonSlurper()
+    def config = jsonSlurper.parseText(content)
+
+    def azureCredential = new AzureCredentials(
+        CredentialsScope.GLOBAL,
+        credentialId,
+        'Azure Service Principal',
+        config.subscriptionId,
+        config.aadClientId,
+        config.aadClientSecret,
+        'https://login.microsoftonline.com/' + config.tenantId + '/oauth2',
+        '',
+        '',
+        '',
+        ''
+    )
+    SystemCredentialsProvider.getInstance().getStore().addCredentials(Domain.global(), azureCredential)
+}
+
 /**
  * Configure Kubernetes plugin
  */
@@ -143,6 +181,8 @@ Thread.start {
     this.createPipeline(githubRepo, 'prod', 'prod')
     // Configure Kubernetes plugin
     this.configureKubernetes()
+    this.addACRCredential('acr', '/etc/kubernetes/azure.json')
+    this.addAzureCredential('azure-sp', '/etc/kubernetes/azure.json')
     // Set number of executor to 0 so that slave agents will be created for each build
     this.setExecutorNum(0)
     // Setup security

--- a/deployment/jenkins/docker-slave/Dockerfile
+++ b/deployment/jenkins/docker-slave/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkinsci/jnlp-slave
+FROM jenkinsci/jnlp-slave:3.7-1
 
 USER root
 


### PR DESCRIPTION
This PR switches to Jenkins App Service Plugin for WebApp deployment. The major changes are:

* Install Azure App service plugin and create credentials for ACR and Service Principle.
* Expose several environment variables to Jenkins slaves through Kubernetes configmap/secrets.
* Modify build step to use Jenkins App Service Plugin.

Note that the docker image `microsoft/java-on-azure-jenkins-mater` also need to be updated once this PR gets merged.