### PR TITLE
Add NSG exceptional rules for the K8s master SSH service

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,16 @@ In this basic layout, the following design decisions have been implemented:
 
    **NOTE**: You can use either a subscription name or id when specifying which subscription to use; to obtain a list of your subscriptions, type `az account list`.
 
+1. **For Microsoft developers**, we have network security group rules applied to the resources
+   in the development subscriptions which restrict the network access from the internal CORP network. 
+   This blocks the SSH communications between the VM's provisioned in this project.
+
+   To workaround this, set the environment variable `MS_CORP` before you start the provision process:
+
+   ```shell
+   export MS_CORP=1
+   ```
+
 1. Build an initial layout on Azure using an ARM template from using one of the following methods:
 
    ```shell

--- a/deployment/lib.sh
+++ b/deployment/lib.sh
@@ -566,7 +566,6 @@ function check_jenkins_readiness()
   do
     jenkins_ip=$(kubectl get svc -o jsonpath={.items[*].status.loadBalancer.ingress[0].ip})
     if [ -n "${jenkins_ip}" ]; then
-      export JENKINS_IP_ADDRESS="$jenkins_ip"
       break;
     fi
     sleep 5

--- a/deployment/provision.sh
+++ b/deployment/provision.sh
@@ -77,6 +77,13 @@ create_secrets_in_kubernetes ${w_eu_group} ${ACS_NAME}
 
 print_banner 'Deploy Jenkins cluster if not exist...'
 deploy_jenkins ${jenkins_group} ${ACS_NAME}
+if [[ -n "$JENKINS_IP_ADDRESS" ]]; then
+    allow_acs_nsg_access "$JENKINS_IP_ADDRESS" "$e_us_group"
+    allow_acs_nsg_access "$JENKINS_IP_ADDRESS" "$w_eu_group"
+    allow_acs_nsg_access "$JENKINS_IP_ADDRESS" "$jenkins_group"
+else
+    echo "WARNING: Jenkins IP address was not found!"
+fi
 
 # Set up environment variables for local dev environment
 source dev_setup.sh "$@"

--- a/deployment/provision.sh
+++ b/deployment/provision.sh
@@ -64,6 +64,12 @@ wait_till_kubernetes_created ${w_eu_group} ${ACS_NAME}
 wait_till_kubernetes_created ${jenkins_group} ${ACS_NAME}
 [[ $? -ne 0 ]] && return 1
 
+if [[ -n "$MS_CORP" ]]; then
+  allow_acs_nsg_access "Internet" "${e_us_group}"
+  allow_acs_nsg_access "Internet" "${w_eu_group}"
+  allow_acs_nsg_access "Internet" "${jenkins_group}"
+fi
+
 wait_till_deployment_created ${c_group} master
 [[ $? -ne 0 ]] && return 1
 
@@ -78,11 +84,11 @@ create_secrets_in_kubernetes ${w_eu_group} ${ACS_NAME}
 print_banner 'Deploy Jenkins cluster if not exist...'
 deploy_jenkins ${jenkins_group} ${ACS_NAME}
 if [[ -n "$JENKINS_IP_ADDRESS" ]]; then
-    allow_acs_nsg_access "$JENKINS_IP_ADDRESS" "$e_us_group"
-    allow_acs_nsg_access "$JENKINS_IP_ADDRESS" "$w_eu_group"
-    allow_acs_nsg_access "$JENKINS_IP_ADDRESS" "$jenkins_group"
+  allow_acs_nsg_access "$JENKINS_IP_ADDRESS" "$e_us_group"
+  allow_acs_nsg_access "$JENKINS_IP_ADDRESS" "$w_eu_group"
+  allow_acs_nsg_access "$JENKINS_IP_ADDRESS" "$jenkins_group"
 else
-    echo "WARNING: Jenkins IP address was not found!"
+  echo "WARNING: Jenkins IP address was not found!"
 fi
 
 # Set up environment variables for local dev environment

--- a/deployment/provision.sh
+++ b/deployment/provision.sh
@@ -65,6 +65,11 @@ wait_till_kubernetes_created ${jenkins_group} ${ACS_NAME}
 [[ $? -ne 0 ]] && return 1
 
 if [[ -n "$MS_CORP" ]]; then
+  # For MS developers, all the VM provisioned will be applied with NSG rules to allow
+  # access only from internal CORP network. This will block the access between the
+  # VMs provisioned for the project, so Jenkins slaves will not be able to access
+  # the ACS master node through SSH port.
+  # This is a fix to this problem.
   allow_acs_nsg_access "Internet" "${e_us_group}"
   allow_acs_nsg_access "Internet" "${w_eu_group}"
   allow_acs_nsg_access "Internet" "${jenkins_group}"
@@ -83,13 +88,6 @@ create_secrets_in_kubernetes ${w_eu_group} ${ACS_NAME}
 
 print_banner 'Deploy Jenkins cluster if not exist...'
 deploy_jenkins ${jenkins_group} ${ACS_NAME}
-if [[ -n "$JENKINS_IP_ADDRESS" ]]; then
-  allow_acs_nsg_access "$JENKINS_IP_ADDRESS" "$e_us_group"
-  allow_acs_nsg_access "$JENKINS_IP_ADDRESS" "$w_eu_group"
-  allow_acs_nsg_access "$JENKINS_IP_ADDRESS" "$jenkins_group"
-else
-  echo "WARNING: Jenkins IP address was not found!"
-fi
 
 # Set up environment variables for local dev environment
 source dev_setup.sh "$@"


### PR DESCRIPTION
This PR addresses the issue #45. **To test, set environment variable `export MS_CORP=1` before provisioning the resources.**

There's a web job scanning for the NSG in MS subscriptions, and apply restrictions on the access to the MS corp network. As a result, if we deploy the resources to the MS subscriptions, they cannot access each other so the CI/CD cannot proceed. (There's only a few exceptional cases like port 443).

We cannot add NSG rules to allow access from a fixed IP address set. We can get the service IP for those pre-allocated services, like the Jenkins master, but we cannot get the public IP for the Jenkins slaves provisioned by the Kubernetes plugin, because they may not have public IP at all.

As a result, an exceptional rule with Internet source to the port 22 was added. The web job deletes the wildcard rule if the port is fixed to 22, so we have our rule defined as `21-23`.

It's working as I tested, however, it is not an ideal solution.

