### PR TITLE
Use azure-acs Jenkins plugin to deploy data app to Azure ACS

### DIFF
--- a/deployment/jenkins/azureutil.groovy
+++ b/deployment/jenkins/azureutil.groovy
@@ -129,8 +129,18 @@ def deployDataApp(String targetEnv, String resGroup) {
         export DATA_APP_CONTAINER_PORT=${config.DATA_APP_CONTAINER_PORT}
         export TARGET_ENV=${targetEnv}
         cd data-app
-        mvn clean fabric8:resource fabric8:apply
+        mvn clean fabric8:resource
+
+        cat target/fabric8/namespace.yml
+        cat target/fabric8/secrets.yml
+        cat target/fabric8/deployment.yml
+        cat target/fabric8/service.yml
+
+        # Jenkins plugin doesn't support apply namespace
+        kubectl apply -f target/fabric8/namespace.yml
     """
+
+    acsDeploy azureCredentialsId: 'azure-sp', configFilePaths: 'data-app/target/fabric8/deployment.yml,data-app/target/fabric8/service.yml', containerService: 'acs | Kubernetes', enableConfigSubstitution: true, resourceGroupName: resGroup, sshCredentialsId: 'acs-ssh'
 
     sh """
         # Check whether there is any redundant IP address


### PR DESCRIPTION
This PR addresses #44 .

azure-acs plugin support [Ant path globs](https://ant.apache.org/manual/dirtasks.html#patterns) for the `configFilePaths` parameter. For the case in this project, there's also other `.yml` file in the folder `data-app/target/fabric8` so we cannot simply apply wildcard `*.yml`. But we can use comma separated file list.